### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,8 @@ You can use [encrypted secrets](https://docs.github.com/en/actions/reference/enc
 
 ```
 - uses: imjasonh/setup-crane@v0.1
-- env:
-    auth_token: ${{ secrets.auth_token }}
   run: |
-    echo "${auth_token}" | crane auth login https://my.registry --username my-username --password-stdin
+    echo "${{ secrets.auth_token }}" | crane auth login https://my.registry --username my-username --password-stdin
     crane digest my.registry/my/image
 ```
 


### PR DESCRIPTION
Passing secret to env may potentially leak the token on the logs. Using it directly into the command line will ofuscate it.