### PR TITLE
Retry downloads in case of failure

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -50,7 +50,11 @@ runs:
         echo "Installing crane @ ${tag} for ${os} on ${arch}"
         tmp=$(mktemp -d)
         cd ${tmp}
-        curl -fsL https://github.com/google/go-containerregistry/releases/download/${tag}/go-containerregistry_${os}_${arch}.tar.gz | tar xz ${out}
+        url=https://github.com/google/go-containerregistry/releases/download/${tag}/go-containerregistry_${os}_${arch}.tar.gz
+        curl -fsL \
+            --remove-on-error --retry 10 --retry-max-time 120 \
+            -o out.tar.gz ${url} | exit 1
+        tar xz -f out.tar.gz ${out}
         chmod +x ${tmp}/${out}
         PATH=${PATH}:${tmp}
         echo "${tmp}" >> $GITHUB_PATH

--- a/action.yml
+++ b/action.yml
@@ -53,7 +53,7 @@ runs:
         url=https://github.com/google/go-containerregistry/releases/download/${tag}/go-containerregistry_${os}_${arch}.tar.gz
         curl -fsL \
             --remove-on-error --retry 10 --retry-max-time 120 \
-            -o out.tar.gz ${url} | exit 1
+            -o out.tar.gz ${url} || exit 1
         tar xz -f out.tar.gz ${out}
         chmod +x ${tmp}/${out}
         PATH=${PATH}:${tmp}


### PR DESCRIPTION
Curl will now retry the download up to 10 times or 2 minutes.